### PR TITLE
change radiko v8 key info url

### DIFF
--- a/content/tech/battle-with-radiko.md
+++ b/content/tech/battle-with-radiko.md
@@ -75,7 +75,7 @@ Tags: radiko,reversing
 
     (Update2: 看到一篇文章讲如何逆向CrackProof，结果只有第一步。)
 
-    (Update3: Radiko v8 使用了Flutter，然后竟然把key打包进去了，路径 /assets/flutter_assets/assets/key/，详见https://github.com/garret1317/yt-dlp-rajiko/blob/f4a74e390da521ef76021b7ba6fdf2874e005311/yt_dlp_plugins/extractor/radiko_key.py ， 以前可是不会犯这个错误的啊，以前是DEBUG版本才会从sdcard路径下读取这个文件)
+    (Update3: Radiko v8 使用了Flutter，然后竟然把key打包进去了，路径 /assets/flutter_assets/assets/key/，详见https://427738.xyz/yt-dlp-rajiko/notes/v8key.html ， 以前可是不会犯这个错误的啊，以前是DEBUG版本才会从sdcard路径下读取这个文件)
 
 7. 还原后的生成函数
     


### PR DESCRIPTION
i wrote a bit more about the radiko v8 key [on my website](https://427738.xyz/yt-dlp-rajiko/notes/v8key.html), i'd appreciate it if you could link there instead please
that way i can use the branch i put that `radiko_key.py` file in without maybe breaking things lol